### PR TITLE
chore: webhooks configuration

### DIFF
--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Entities/ActionNotifier.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Entities/ActionNotifier.cs
@@ -20,7 +20,7 @@ public class ActionNotifier : IActionNotifier
 
     public async Task ApplyInComments(WebhookEvent webhookEvent, long issueNumber, string hook)
     {
-        ParseWebhookEvent(webhookEvent, out var repository, out var installation);
+        ParseWebhookEvent(webhookEvent, out Repository repository, out InstallationLite installation);
 
         var installationClient = await _installationClientFactory.GetClient(installation.Id);
 
@@ -33,7 +33,7 @@ public class ActionNotifier : IActionNotifier
 
     public async Task ReactInComments(WebhookEvent webhookEvent, long commentId, bool isSuccessful)
     {
-        ParseWebhookEvent(webhookEvent, out var repository, out var installation);
+        ParseWebhookEvent(webhookEvent, out Repository repository, out InstallationLite installation);
 
         var installationClient = await _installationClientFactory.GetClient(installation.Id);
 

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Entities/IActionNotifier.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Entities/IActionNotifier.cs
@@ -5,4 +5,5 @@ namespace Kysect.Shreks.Integration.Github.Entities;
 public interface IActionNotifier
 { 
     Task ApplyInComments(WebhookEvent webhookEvent, long issueNumber, string hook);
+    Task ReactInComments(WebhookEvent webhookEvent, long commentId, bool isSuccessful);
 }

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Extensions/AppBuilderExtensions.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Extensions/AppBuilderExtensions.cs
@@ -11,7 +11,7 @@ public static class AppBuilderExtensions
         var gitHubConf = shreksConfiguration.GithubConfiguration;
 
         app.UseRouting()
-            .UseEndpoints(endpoints => endpoints.MapGitHubWebhooks(secret: gitHubConf.Secret));
+            .UseEndpoints(endpoints => endpoints.MapGitHubWebhooks(secret: gitHubConf.GithubAppSecret));
 
         return app;
     }

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Helpers/GithubConfiguration.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Helpers/GithubConfiguration.cs
@@ -3,15 +3,21 @@ namespace Kysect.Shreks.Integration.Github.Helpers;
 public class GithubConfiguration : IShreksConfiguration
 {
     public string? PrivateKeySource { get; init; }
-    public string? Secret { get; init; }
     public int AppIntegrationId { get; init; }
     public int ExpirationSeconds { get; init; }
     public string? Organization { get; init; }
+    public string? GithubAppSecret { get; private set; }
+
+    public void SetGithubAppSecret(string githubAppSecret)
+    {
+        ArgumentNullException.ThrowIfNull(githubAppSecret, nameof(githubAppSecret));
+        GithubAppSecret = githubAppSecret;
+    }
 
     public void Verify()
     {
         ArgumentNullException.ThrowIfNull(Organization, nameof(Organization));
-        ArgumentNullException.ThrowIfNull(Secret, nameof(Secret));
+        ArgumentNullException.ThrowIfNull(GithubAppSecret, nameof(GithubAppSecret));
         ArgumentNullException.ThrowIfNull(PrivateKeySource, nameof(PrivateKeySource));
 
         if (ExpirationSeconds <= 0)

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Helpers/ShreksConfiguration.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Helpers/ShreksConfiguration.cs
@@ -6,6 +6,12 @@ public sealed class ShreksConfiguration : IShreksConfiguration
     public CacheEntryConfiguration CacheEntryConfiguration { get; init; }
     public GithubConfiguration GithubConfiguration { get; init; }
 
+    public ShreksConfiguration AppendSecret(string githubAppSecret)
+    {
+        GithubConfiguration.SetGithubAppSecret(githubAppSecret);
+        return this;
+    }
+
     public void Verify()
     {
         CacheConfiguration.Verify();

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Processors/ShreksWebhookEventProcessor.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Processors/ShreksWebhookEventProcessor.cs
@@ -42,7 +42,7 @@ public sealed class ShreksWebhookEventProcessor : WebhookEventProcessor
 
         await _actionNotifier.ApplyInComments(
             pullRequestEvent, 
-            (int) pullRequestEvent.PullRequest.Number,
+            pullRequestEvent.PullRequest.Number,
             nameof(ProcessPullRequestWebhookAsync));
     }
 
@@ -69,7 +69,7 @@ public sealed class ShreksWebhookEventProcessor : WebhookEventProcessor
 
         await _actionNotifier.ApplyInComments(
             pullRequestReviewEvent,
-            (int) pullRequestReviewEvent.PullRequest.Number,
+            pullRequestReviewEvent.PullRequest.Number,
             nameof(ProcessPullRequestWebhookAsync));
     }
 
@@ -96,8 +96,13 @@ public sealed class ShreksWebhookEventProcessor : WebhookEventProcessor
 
         await _actionNotifier.ApplyInComments(
             issueCommentEvent,
-            (int) issueCommentEvent.Issue.Number,
+            issueCommentEvent.Issue.Number,
             nameof(ProcessIssueCommentWebhookAsync));
+
+        await _actionNotifier.ReactInComments(
+            issueCommentEvent,
+            issueCommentEvent.Comment.Id,
+            true);
     }
 
     private bool IsSenderBotOrNull(WebhookEvent webhookEvent) => webhookEvent.Sender is null || webhookEvent.Sender.Type == UserType.Bot;

--- a/Source/Playground/Kysect.Shreks.Playground.Github/Kysect.Shreks.Playground.Github.csproj
+++ b/Source/Playground/Kysect.Shreks.Playground.Github/Kysect.Shreks.Playground.Github.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
+        <UserSecretsId>1b641d05-7511-4812-9ed4-0a7f6820520c</UserSecretsId>
+  </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />

--- a/Source/Playground/Kysect.Shreks.Playground.Github/Program.cs
+++ b/Source/Playground/Kysect.Shreks.Playground.Github/Program.cs
@@ -10,7 +10,7 @@ Log.Logger = new LoggerConfiguration()
 var builder = WebApplication.CreateBuilder(args);
 
 var shreksConfiguration = builder.Configuration.GetSection(nameof(ShreksConfiguration)).Get<ShreksConfiguration>();
-shreksConfiguration.Verify();
+shreksConfiguration.AppendSecret(builder.Configuration["GithubAppSecret"]).Verify();
 
 builder.Services
     .AddGithubServices(shreksConfiguration)

--- a/Source/Playground/Kysect.Shreks.Playground.Github/appsettings.Development.json
+++ b/Source/Playground/Kysect.Shreks.Playground.Github/appsettings.Development.json
@@ -8,11 +8,11 @@
   "AllowedHosts": "*",
   "ShreksConfiguration": {
     "GithubConfiguration": {
-      "PrivateKeySource": "shreks-webhooks-handler-test.2022-07-13.private-key.pem",
-      "Secret": "TestHookSecret",
-      "AppIntegrationId": 219746,
+      "PrivateKeySource": "shreks-bot.pem",
+      "Secret": "ShreksSecret",
+      "AppIntegrationId": 226239,
       "ExpirationSeconds": 600,
-      "Organization": "Kysect"
+      "Organization": "is-prog-y26"
     },
     "CacheConfiguration": {
       "SizeLimit": 10,

--- a/Source/Playground/Kysect.Shreks.Playground.Github/appsettings.Development.json
+++ b/Source/Playground/Kysect.Shreks.Playground.Github/appsettings.Development.json
@@ -9,7 +9,6 @@
   "ShreksConfiguration": {
     "GithubConfiguration": {
       "PrivateKeySource": "shreks-bot.pem",
-      "Secret": "ShreksSecret",
       "AppIntegrationId": 226239,
       "ExpirationSeconds": 600,
       "Organization": "is-prog-y26"


### PR DESCRIPTION
После создания нового инстанса GithubApp необходимо было обновить конфигурацию для запуска хендлеров.

Также я немного пересмотрел то, как мы храним секреты _(в частности секрет для авторизации GithubApp)_ и немного изменил это поведение.

Честно говоря, не знаю, как это будет работать с гитом, но, скорее всего, для запуска локального хоста вам теперь нужно:

1. Закинуть файл `.pem` с ключом в корень `Github.Playground` проекта _(как и раньше)_
2. **Скорее всего** понадобится прописать в консоли следующее:
    ```bash
    dotnet user-secrets set "GithubAppSecret" "<secret_value>"
    ```
    `<secret_value>` - секрет, который задаётся в Github App для авторизации