### PR TITLE
Typo in naming

### DIFF
--- a/Source/Application/Kysect.Shreks.Application.Abstractions/Github/Queries/GetUserCourseRole.cs
+++ b/Source/Application/Kysect.Shreks.Application.Abstractions/Github/Queries/GetUserCourseRole.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace Kysect.Shreks.Application.Abstractions.Github.Queries;
 
-public class GerUserCourseRole
+public class GetUserCourseRole
 {
     public record Query(Guid SubjectCourseId, Guid UserId) : IRequest<Response>;
     public record Response(UserCourseRole Role);    

--- a/Source/Application/Kysect.Shreks.Application.Abstractions/Github/Queries/GetUserCourseRole.cs
+++ b/Source/Application/Kysect.Shreks.Application.Abstractions/Github/Queries/GetUserCourseRole.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace Kysect.Shreks.Application.Abstractions.Github.Queries;
 
-public class GetUserCourseRole
+public static class GetUserCourseRole
 {
     public record Query(Guid SubjectCourseId, Guid UserId) : IRequest<Response>;
     public record Response(UserCourseRole Role);    

--- a/Source/Application/Kysect.Shreks.Application.Handlers/Users/GetUserCourseRoleHandler.cs
+++ b/Source/Application/Kysect.Shreks.Application.Handlers/Users/GetUserCourseRoleHandler.cs
@@ -2,7 +2,7 @@
 using Kysect.Shreks.DataAccess.Abstractions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using static Kysect.Shreks.Application.Abstractions.Github.Queries.GerUserCourseRole;
+using static Kysect.Shreks.Application.Abstractions.Github.Queries.GetUserCourseRole;
 
 namespace Kysect.Shreks.Application.Handlers.Users;
 


### PR DESCRIPTION
По горячим следам. @hrrrrustic делал пр, сначала всё ок было, а когда по папкам/файлом переносил, опечатался.