### PR TITLE
fix: do not create two instance of google worker

### DIFF
--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/Extensions/ServiceCollectionExtensions.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/Extensions/ServiceCollectionExtensions.cs
@@ -31,9 +31,9 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ISheetManagementService, SheetManagementService>()
             .AddSingleton<ISheetBuilder, SheetBuilder>()
             .AddSingleton<IComponentRenderer<GoogleSheetRenderCommand>, GoogleSheetComponentRenderer>()
+            .AddSingleton<TableUpdateQueue>()
+            .AddSingleton<ITableUpdateQueue>(p => p.GetRequiredService<TableUpdateQueue>())
             .AddSingleton<GoogleTableAccessor>()
-            .AddSingleton(p => new GoogleTableUpdateWorker(p.GetRequiredService<GoogleTableAccessor>()))
-            .AddSingleton<ITableUpdateQueue>(p => p.GetRequiredService<GoogleTableUpdateWorker>())
             .AddHostedService<GoogleTableUpdateWorker>();
     }
 }

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/GoogleTableUpdateWorker.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/GoogleTableUpdateWorker.cs
@@ -9,7 +9,7 @@ public class GoogleTableUpdateWorker : BackgroundService
     private readonly GoogleTableAccessor _tableAccessor;
     private readonly TableUpdateQueue _tableUpdateQueue;
 
-    public GoogleTableUpdateWorker(GoogleTableAccessor tableAccessor, TableUpdateQueue tableUpdateQueue)
+    internal GoogleTableUpdateWorker(GoogleTableAccessor tableAccessor, TableUpdateQueue tableUpdateQueue)
     {
         _tableAccessor = tableAccessor;
         _tableUpdateQueue = tableUpdateQueue;

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/TableUpdateQueue.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/TableUpdateQueue.cs
@@ -1,0 +1,26 @@
+﻿using Kysect.Shreks.Application.Abstractions.Google;
+using Kysect.Shreks.Integration.Google.Models;
+
+namespace Kysect.Shreks.Integration.Google;
+
+public class TableUpdateQueue : ITableUpdateQueue
+{
+    public ConcurrentHashSet<Guid> QueueUpdateSubjectCourseIds { get; }
+    public ConcurrentHashSet<Guid> PointsUpdateSubjectCourseIds { get; }
+
+    public TableUpdateQueue()
+    {
+        QueueUpdateSubjectCourseIds = new ConcurrentHashSet<Guid>();
+        PointsUpdateSubjectCourseIds = new ConcurrentHashSet<Guid>();
+    }
+
+    public void EnqueueSubmissionsQueueUpdate(Guid subjectCourseId)
+    {
+        QueueUpdateSubjectCourseIds.Add(subjectCourseId);
+    }
+
+    public void EnqueueCoursePointsUpdate(Guid subjectCourseId)
+    {
+        PointsUpdateSubjectCourseIds.Add(subjectCourseId);
+    }
+}

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/TableUpdateQueue.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/TableUpdateQueue.cs
@@ -3,7 +3,7 @@ using Kysect.Shreks.Integration.Google.Models;
 
 namespace Kysect.Shreks.Integration.Google;
 
-public class TableUpdateQueue : ITableUpdateQueue
+internal class TableUpdateQueue : ITableUpdateQueue
 {
     public ConcurrentHashSet<Guid> QueueUpdateSubjectCourseIds { get; }
     public ConcurrentHashSet<Guid> PointsUpdateSubjectCourseIds { get; }

--- a/Source/Playground/Kysect.Shreks.Playground.Google/Program.cs
+++ b/Source/Playground/Kysect.Shreks.Playground.Google/Program.cs
@@ -51,24 +51,25 @@ await services.UseDatabaseSeeders();
 
 var subjectCourse = databaseContext.SubjectCourses.First();
 
+var tableQueue = services.GetRequiredService<TableUpdateQueue>();
 var tableWorker = services.GetRequiredService<GoogleTableUpdateWorker>();
 
 await tableWorker.StartAsync(default);
 
-tableWorker.EnqueueCoursePointsUpdate(subjectCourse.Id);
-tableWorker.EnqueueSubmissionsQueueUpdate(subjectCourse.Id);
+tableQueue.EnqueueCoursePointsUpdate(subjectCourse.Id);
+tableQueue.EnqueueSubmissionsQueueUpdate(subjectCourse.Id);
 
 await Task.Delay(TimeSpan.FromSeconds(30));
 
 var anotherSubjectCourse = databaseContext.SubjectCourses.Skip(1).First();
-tableWorker.EnqueueCoursePointsUpdate(anotherSubjectCourse.Id);
-tableWorker.EnqueueSubmissionsQueueUpdate(anotherSubjectCourse.Id);
+tableQueue.EnqueueCoursePointsUpdate(anotherSubjectCourse.Id);
+tableQueue.EnqueueSubmissionsQueueUpdate(anotherSubjectCourse.Id);
 
 await Task.Delay(TimeSpan.FromMinutes(2));
 
-tableWorker.EnqueueCoursePointsUpdate(subjectCourse.Id);
-tableWorker.EnqueueSubmissionsQueueUpdate(subjectCourse.Id);
-tableWorker.EnqueueCoursePointsUpdate(subjectCourse.Id);
-tableWorker.EnqueueSubmissionsQueueUpdate(subjectCourse.Id);
+tableQueue.EnqueueCoursePointsUpdate(subjectCourse.Id);
+tableQueue.EnqueueSubmissionsQueueUpdate(subjectCourse.Id);
+tableQueue.EnqueueCoursePointsUpdate(subjectCourse.Id);
+tableQueue.EnqueueSubmissionsQueueUpdate(subjectCourse.Id);
 
 await Task.Delay(-1);

--- a/Source/Playground/Kysect.Shreks.Playground.Google/Program.cs
+++ b/Source/Playground/Kysect.Shreks.Playground.Google/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Google.Apis.Auth.OAuth2;
 using Kysect.Shreks.Application.Abstractions.Formatters;
+using Kysect.Shreks.Application.Abstractions.Google;
 using Kysect.Shreks.Application.Handlers.Extensions;
 using Kysect.Shreks.Core.Study;
 using Kysect.Shreks.Core.Users;
@@ -51,7 +52,7 @@ await services.UseDatabaseSeeders();
 
 var subjectCourse = databaseContext.SubjectCourses.First();
 
-var tableQueue = services.GetRequiredService<TableUpdateQueue>();
+var tableQueue = services.GetRequiredService<ITableUpdateQueue>();
 var tableWorker = services.GetRequiredService<GoogleTableUpdateWorker>();
 
 await tableWorker.StartAsync(default);


### PR DESCRIPTION
Отпилил от воркера реализацию интерфейса очереди - он не является очередью и не должен. Создал реализацию. Во всех местах будем использовать интерфейс, а в воркере - сам класс у которого паблик хеш сеты.