### PR TITLE
fix: make GoogleTableAccessor scoped for preventing error with scoped  in singleton

### DIFF
--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/Extensions/ServiceCollectionExtensions.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/Extensions/ServiceCollectionExtensions.cs
@@ -31,8 +31,8 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ISheetManagementService, SheetManagementService>()
             .AddSingleton<ISheetBuilder, SheetBuilder>()
             .AddSingleton<IComponentRenderer<GoogleSheetRenderCommand>, GoogleSheetComponentRenderer>()
-            .AddSingleton<GoogleTableAccessor>()
-            .AddSingleton(p => new GoogleTableUpdateWorker(p.GetRequiredService<GoogleTableAccessor>()))
+            .AddScoped<GoogleTableAccessor>()
+            .AddSingleton<GoogleTableUpdateWorker>()
             .AddSingleton<ITableUpdateQueue>(p => p.GetRequiredService<GoogleTableUpdateWorker>())
             .AddHostedService<GoogleTableUpdateWorker>();
     }

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/GoogleTableUpdateWorker.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/GoogleTableUpdateWorker.cs
@@ -1,5 +1,6 @@
 ﻿using Kysect.Shreks.Application.Abstractions.Google;
 using Kysect.Shreks.Integration.Google.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Kysect.Shreks.Integration.Google;
@@ -11,11 +12,11 @@ public class GoogleTableUpdateWorker : BackgroundService, ITableUpdateQueue
     private readonly ConcurrentHashSet<Guid> _queueUpdateSubjectCourseIds;
     private readonly ConcurrentHashSet<Guid> _pointsUpdateSubjectCourseIds;
 
-    private readonly GoogleTableAccessor _tableAccessor;
-
-    public GoogleTableUpdateWorker(GoogleTableAccessor tableAccessor)
+    private readonly IServiceScopeFactory _serviceProvider;
+    
+    public GoogleTableUpdateWorker(IServiceScopeFactory serviceProvider)
     {
-        _tableAccessor = tableAccessor;
+        _serviceProvider = serviceProvider;
 
         _queueUpdateSubjectCourseIds = new ConcurrentHashSet<Guid>();
         _pointsUpdateSubjectCourseIds = new ConcurrentHashSet<Guid>();
@@ -26,15 +27,21 @@ public class GoogleTableUpdateWorker : BackgroundService, ITableUpdateQueue
         using var timer = new PeriodicTimer(DelayBetweenSheetUpdates);
         while (!token.IsCancellationRequested && await timer.WaitForNextTickAsync(token))
         {
-            var pointsUpdateTasks = _pointsUpdateSubjectCourseIds
-                .GetAndClearValues()
-                .Select(i => _tableAccessor.UpdatePointsAsync(i, token));
+            using (IServiceScope serviceScope = _serviceProvider.CreateScope())
+            {
+                using (var googleTableAccessor = serviceScope.ServiceProvider.GetRequiredService<GoogleTableAccessor>())
+                {
+                    var pointsUpdateTasks = _pointsUpdateSubjectCourseIds
+                        .GetAndClearValues()
+                        .Select(i => googleTableAccessor.UpdatePointsAsync(i, token));
 
-            var queueUpdateTasks = _queueUpdateSubjectCourseIds
-                .GetAndClearValues()
-                .Select(i => _tableAccessor.UpdateQueueAsync(i, token));
+                    var queueUpdateTasks = _queueUpdateSubjectCourseIds
+                        .GetAndClearValues()
+                        .Select(i => googleTableAccessor.UpdateQueueAsync(i, token));
 
-            await Task.WhenAll(pointsUpdateTasks.Concat(queueUpdateTasks));
+                    await Task.WhenAll(pointsUpdateTasks.Concat(queueUpdateTasks));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Внутри GoogleTableAccessor  вызывается медиатор. Я очень хотел его оттуда выпилить полностью, но это займёт очень много времени. Пока остановился на варианте, когда этот accessor создаётся в цикле как scoped.