### PR TITLE
fix: start github worker every 6 hours instead of 24

### DIFF
--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Invites/GithubInvitingWorker.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Invites/GithubInvitingWorker.cs
@@ -11,8 +11,9 @@ public class GithubInvitingWorker : BackgroundService
     /// <summary>
     /// This worker is our restriction bypass, github allow to invite only 50 users per 24 hours.
     /// So we need to send invites every 24 hours + 1 minutes shift for preventing race conditions.
+    /// But in case of restart it is better to try many time. Anyways we have logic for stop inviting after first fail.
     /// </summary>
-    private readonly TimeSpan _delayBetweenInviteIteration = TimeSpan.FromHours(24).Add(TimeSpan.FromMinutes(1));
+    private readonly TimeSpan _delayBetweenInviteIteration = TimeSpan.FromHours(6);
 
     private readonly ILogger<GithubInvitingWorker> _logger;
     private readonly IServiceScopeFactory _serviceProvider;


### PR DESCRIPTION
Проблема в том, что запуск раз в сутки - это не очень хорошо. Когда у нас рестарты идут и всё такое, то мы можем не заметить, как ничего не отработало.