### PR TITLE
Fix: GetCurrentUnratedSubmissionByPrNumberHandler EF Expression translator fix.

### DIFF
--- a/Source/Application/Kysect.Shreks.Application.Handlers/Github/GetCurrentUnratedSumbissionByPrNumberHandler.cs
+++ b/Source/Application/Kysect.Shreks.Application.Handlers/Github/GetCurrentUnratedSumbissionByPrNumberHandler.cs
@@ -22,15 +22,16 @@ public class GetCurrentUnratedSubmissionByPrNumberHandler : IRequestHandler<Quer
 
     public async Task<Response> Handle(Query request, CancellationToken cancellationToken)
     {
-        var submission =  _context.SubmissionAssociations
+        var submission = await _context.SubmissionAssociations
             .OfType<GithubSubmissionAssociation>()
             .Where(a =>
                 a.Organization == request.PullRequestDescriptor.Organization
                 && a.Repository == request.PullRequestDescriptor.Repository
                 && a.PrNumber == request.PullRequestDescriptor.PrNumber
                 && a.Submission.Rating == null)
+            .OrderByDescending(a => a.Submission.SubmissionDate)
             .Select(a => a.Submission)
-            .MaxBy(s => s.SubmissionDate);
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (submission is null)
         {

--- a/Source/Application/Kysect.Shreks.Application.Handlers/Github/GetLastSubmissionByPrHandler.cs
+++ b/Source/Application/Kysect.Shreks.Application.Handlers/Github/GetLastSubmissionByPrHandler.cs
@@ -22,14 +22,15 @@ public class GetLastSubmissionByPrHandler : IRequestHandler<Query, Response>
 
     public async Task<Response> Handle(Query request, CancellationToken cancellationToken)
     {
-        var submission = _context.SubmissionAssociations
+        var submission = await _context.SubmissionAssociations
             .OfType<GithubSubmissionAssociation>()
             .Where(a =>
                 a.Organization == request.PullRequestDescriptor.Organization
                 && a.Repository == request.PullRequestDescriptor.Repository
                 && a.PrNumber == request.PullRequestDescriptor.PrNumber)
-            .Select(s => s.Submission)
-            .MaxBy(s => s.SubmissionDate);
+            .OrderByDescending(a => a.Submission.SubmissionDate)
+            .Select(a => a.Submission)
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (submission is null)
         {


### PR DESCRIPTION
Closes #343

Revert "Refactor: max by usage"
This reverts commit ae08ef38b236aecd00014163b29776da832ffb8b.