### PR TITLE
refactor: extract table logic

### DIFF
--- a/Docker/build.dockerfile
+++ b/Docker/build.dockerfile
@@ -13,6 +13,7 @@ COPY ./Application/Kysect.Shreks.DataAccess.Abstractions/Kysect.Shreks.DataAcces
 COPY ./Application/Kysect.Shreks.Application.Abstractions/Kysect.Shreks.Application.Abstractions.csproj ./Application/Kysect.Shreks.Application.Abstractions/Kysect.Shreks.Application.Abstractions.csproj
 COPY ./Application/Kysect.Shreks.Application/Kysect.Shreks.Application.csproj ./Application/Kysect.Shreks.Application/Kysect.Shreks.Application.csproj
 COPY ./Application/Kysect.Shreks.Application.Dto/Kysect.Shreks.Application.Dto.csproj ./Application/Kysect.Shreks.Application.Dto/Kysect.Shreks.Application.Dto.csproj
+COPY ./Application/Kysect.Shreks.Application.TableManagement/Kysect.Shreks.Application.TableManagement.csproj ./Application/Kysect.Shreks.Application.TableManagement/Kysect.Shreks.Application.TableManagement.csproj
 COPY ./Infrastructure/Kysect.Shreks.Seeding/Kysect.Shreks.Seeding.csproj ./Infrastructure/Kysect.Shreks.Seeding/Kysect.Shreks.Seeding.csproj
 COPY ./Infrastructure/Integration/Kysect.Shreks.Integration.Github/Kysect.Shreks.Integration.Github.csproj ./Infrastructure/Integration/Kysect.Shreks.Integration.Github/Kysect.Shreks.Integration.Github.csproj
 COPY ./Infrastructure/Integration/Kysect.Shreks.Integration.Google/Kysect.Shreks.Integration.Google.csproj ./Infrastructure/Integration/Kysect.Shreks.Integration.Google/Kysect.Shreks.Integration.Google.csproj

--- a/Source/Application/Kysect.Shreks.Application.TableManagement/ConcurrentHashSet.cs
+++ b/Source/Application/Kysect.Shreks.Application.TableManagement/ConcurrentHashSet.cs
@@ -1,4 +1,4 @@
-﻿namespace Kysect.Shreks.Integration.Google.Models;
+﻿namespace Kysect.Shreks.Application.TableManagement;
 
 public class ConcurrentHashSet<T>
 {

--- a/Source/Application/Kysect.Shreks.Application.TableManagement/GoogleTableUpdateWorker.cs
+++ b/Source/Application/Kysect.Shreks.Application.TableManagement/GoogleTableUpdateWorker.cs
@@ -1,9 +1,9 @@
-﻿using System.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
-namespace Kysect.Shreks.Integration.Google;
+namespace Kysect.Shreks.Application.TableManagement;
 
 public class GoogleTableUpdateWorker : BackgroundService
 {
@@ -31,7 +31,7 @@ public class GoogleTableUpdateWorker : BackgroundService
         while (!token.IsCancellationRequested && await timer.WaitForNextTickAsync(token))
         {
             using IServiceScope serviceScope = _serviceProvider.CreateScope();
-            using var googleTableAccessor = serviceScope.ServiceProvider.GetRequiredService<GoogleTableAccessor>();
+            using var googleTableAccessor = serviceScope.ServiceProvider.GetRequiredService<ITableAccessor>();
 
             _stopwatch.Restart();
 
@@ -45,7 +45,7 @@ public class GoogleTableUpdateWorker : BackgroundService
         }
     }
 
-    private async Task<bool> UpdateTablePoints(GoogleTableAccessor googleTableAccessor, CancellationToken token)
+    private async Task<bool> UpdateTablePoints(ITableAccessor googleTableAccessor, CancellationToken token)
     {
         IReadOnlyCollection<Guid> points = _tableUpdateQueue
             .PointsUpdateSubjectCourseIds
@@ -60,7 +60,7 @@ public class GoogleTableUpdateWorker : BackgroundService
         return points.Any();
     }
 
-    private async Task<bool> UpdateTableQueue(GoogleTableAccessor googleTableAccessor, CancellationToken token)
+    private async Task<bool> UpdateTableQueue(ITableAccessor googleTableAccessor, CancellationToken token)
     {
         IReadOnlyCollection<(Guid, Guid)> queues = _tableUpdateQueue
             .QueueUpdateSubjectCourseGroupIds

--- a/Source/Application/Kysect.Shreks.Application.TableManagement/ITableAccessor.cs
+++ b/Source/Application/Kysect.Shreks.Application.TableManagement/ITableAccessor.cs
@@ -1,0 +1,7 @@
+﻿namespace Kysect.Shreks.Application.TableManagement;
+
+public interface ITableAccessor : IDisposable
+{
+    Task UpdatePointsAsync(Guid subjectCourseId, CancellationToken token);
+    Task UpdateQueueAsync(Guid subjectCourseId, Guid studentGroupId, CancellationToken token);
+}

--- a/Source/Application/Kysect.Shreks.Application.TableManagement/Kysect.Shreks.Application.TableManagement.csproj
+++ b/Source/Application/Kysect.Shreks.Application.TableManagement/Kysect.Shreks.Application.TableManagement.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Domain\Kysect.Shreks.Common\Kysect.Shreks.Common.csproj" />
+    <ProjectReference Include="..\Kysect.Shreks.Application.Abstractions\Kysect.Shreks.Application.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Application/Kysect.Shreks.Application.TableManagement/TableUpdateQueue.cs
+++ b/Source/Application/Kysect.Shreks.Application.TableManagement/TableUpdateQueue.cs
@@ -1,7 +1,6 @@
 ﻿using Kysect.Shreks.Application.Abstractions.Google;
-using Kysect.Shreks.Integration.Google.Models;
 
-namespace Kysect.Shreks.Integration.Google;
+namespace Kysect.Shreks.Application.TableManagement;
 
 public class TableUpdateQueue : ITableUpdateQueue
 {

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/Extensions/ServiceCollectionExtensions.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using FluentSpreadsheets.Tables;
 using Kysect.Shreks.Application.Abstractions.Formatters;
 using Kysect.Shreks.Application.Abstractions.Google;
 using Kysect.Shreks.Application.Dto.Tables;
+using Kysect.Shreks.Application.TableManagement;
 using Kysect.Shreks.Integration.Google.Options;
 using Kysect.Shreks.Integration.Google.Providers;
 using Kysect.Shreks.Integration.Google.Sheets;
@@ -56,7 +57,7 @@ public static class ServiceCollectionExtensions
         return serviceCollection
             .AddSingleton<TableUpdateQueue>()
             .AddSingleton<ITableUpdateQueue>(p => p.GetRequiredService<TableUpdateQueue>())
-            .AddScoped<GoogleTableAccessor>()
+            .AddScoped<ITableAccessor, GoogleTableAccessor>()
             .AddHostedService<GoogleTableUpdateWorker>();
     }
 

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/GoogleTableAccessor.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/GoogleTableAccessor.cs
@@ -1,6 +1,7 @@
 ﻿using Kysect.Shreks.Application.Abstractions.Google.Commands;
 using Kysect.Shreks.Application.Abstractions.Google.Queries;
 using Kysect.Shreks.Application.Dto.Tables;
+using Kysect.Shreks.Application.TableManagement;
 using Kysect.Shreks.Integration.Google.Sheets;
 using Kysect.Shreks.Integration.Google.Tools;
 using MediatR;
@@ -8,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Kysect.Shreks.Integration.Google;
 
-public class GoogleTableAccessor : IDisposable
+public class GoogleTableAccessor : ITableAccessor
 {
     private readonly SemaphoreSlim _spreadsheetCreationSemaphore;
 

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/Kysect.Shreks.Integration.Google.csproj
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Google/Kysect.Shreks.Integration.Google.csproj
@@ -17,8 +17,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference
-			Include="..\..\..\Application\Kysect.Shreks.Application.Abstractions\Kysect.Shreks.Application.Abstractions.csproj" />
+		<ProjectReference Include="..\..\..\Application\Kysect.Shreks.Application.Abstractions\Kysect.Shreks.Application.Abstractions.csproj" />
+		<ProjectReference Include="..\..\..\Application\Kysect.Shreks.Application.TableManagement\Kysect.Shreks.Application.TableManagement.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Source/Kysect.Shreks.WebApi/Controllers/GoogleController.cs
+++ b/Source/Kysect.Shreks.WebApi/Controllers/GoogleController.cs
@@ -1,4 +1,5 @@
-﻿using Kysect.Shreks.Integration.Google;
+﻿using Kysect.Shreks.Application.TableManagement;
+using Kysect.Shreks.Integration.Google;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Kysect.Shreks.WebApi.Controllers

--- a/Source/Kysect.Shreks.sln
+++ b/Source/Kysect.Shreks.sln
@@ -68,6 +68,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kysect.Shreks.Application.TableManagement", "Application\Kysect.Shreks.Application.TableManagement\Kysect.Shreks.Application.TableManagement.csproj", "{A57B6F3D-1DC1-41A7-90CD-99158B4D55DA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -166,6 +168,10 @@ Global
 		{3B0EB40E-6E3C-4F8D-BBD7-9B7FC5FB7D68}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B0EB40E-6E3C-4F8D-BBD7-9B7FC5FB7D68}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B0EB40E-6E3C-4F8D-BBD7-9B7FC5FB7D68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A57B6F3D-1DC1-41A7-90CD-99158B4D55DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A57B6F3D-1DC1-41A7-90CD-99158B4D55DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A57B6F3D-1DC1-41A7-90CD-99158B4D55DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A57B6F3D-1DC1-41A7-90CD-99158B4D55DA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -195,6 +201,7 @@ Global
 		{601BCCAB-8895-43CB-BC46-EE2C20F4031F} = {DC866D57-D41E-455D-BD7D-85F1DD575823}
 		{DF0C2310-8F92-404C-885E-D495B3F334EB} = {AE556858-2A9D-481F-9235-3C74F0CDC5A5}
 		{3B0EB40E-6E3C-4F8D-BBD7-9B7FC5FB7D68} = {AE556858-2A9D-481F-9235-3C74F0CDC5A5}
+		{A57B6F3D-1DC1-41A7-90CD-99158B4D55DA} = {AE556858-2A9D-481F-9235-3C74F0CDC5A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD5C67DB-70F8-4C47-A3F4-7C94BECE1657}

--- a/Source/Playground/Kysect.Shreks.Playground.Google/Program.cs
+++ b/Source/Playground/Kysect.Shreks.Playground.Google/Program.cs
@@ -2,6 +2,7 @@
 using Google.Apis.Auth.OAuth2;
 using Kysect.Shreks.Application.Abstractions.Google;
 using Kysect.Shreks.Application.Extensions;
+using Kysect.Shreks.Application.TableManagement;
 using Kysect.Shreks.DataAccess.Context;
 using Kysect.Shreks.Integration.Google;
 using Kysect.Shreks.Integration.Google.Extensions;

--- a/Source/Tests/Kysect.Shreks.Tests/Application/UpdateSubmissionStateHandlerTest.cs
+++ b/Source/Tests/Kysect.Shreks.Tests/Application/UpdateSubmissionStateHandlerTest.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Kysect.Shreks.Application.Commands.Processors;
+using Kysect.Shreks.Application.TableManagement;
 using Kysect.Shreks.Core.Models;
 using Kysect.Shreks.Core.Submissions;
 using Kysect.Shreks.Integration.Google;


### PR DESCRIPTION
ref to #432

Попытался начать писать тесты на очередь и наткнулся на то, что логика очереди в GoogleIntegration лежит частично. Постарался минимальными изменениями вынести первый кусок - воркер.

- Что хочется в итоге: возможность написать текст, когда меняется сабмишен и мы можем проверить, что в очередь попал запрос на перегенерацию
- Что нужно следующим шагом сделать: резать GoogleTableAccessor, вынести с него CreateSpreadsheetAsync в апликейшен