### PR TITLE
fix: do not override domain exceptions

### DIFF
--- a/Source/Application/Kysect.Shreks.Application.Commands/Processors/ShreksCommandProcessor.cs
+++ b/Source/Application/Kysect.Shreks.Application.Commands/Processors/ShreksCommandProcessor.cs
@@ -26,7 +26,7 @@ public class ShreksCommandProcessor
         {
             return await ProcessBaseCommand(command, cancellationToken);
         }
-        catch (DomainInvalidOperationException e)
+        catch (ShreksDomainException e)
         {
             var message = $"An error occurred while processing {command.GetType().Name} command: {e.Message}";
             _logger.LogError(e, message);


### PR DESCRIPTION
Заюзали не тот экспшен. Как итог, все эксепшены превращались в Contact support for details