### PR TITLE
Fix help command context creation

### DIFF
--- a/Source/Application/Kysect.Shreks.Application.Commands/Processors/ShreksCommandProcessor.cs
+++ b/Source/Application/Kysect.Shreks.Application.Commands/Processors/ShreksCommandProcessor.cs
@@ -74,7 +74,7 @@ public class ShreksCommandProcessor
 
             case HelpCommand helpCommand:
             {
-                SubmissionContext context = await _commandContextFactory.CreateSubmissionContext(cancellationToken);
+                BaseContext context = await _commandContextFactory.CreateBaseContext(cancellationToken);
                 string result = helpCommand.ExecuteAsync(context, _logger);
                 return BaseShreksCommandResult.Success(result);
             }


### PR DESCRIPTION
Для /help команды всё ещё создавали неправильный контекст.