### PR TITLE
Test GitHub workflow - open, close events

### DIFF
--- a/Source/Application/Kysect.Shreks.Application.GithubWorkflow.Abstractions/IShreksWebhookEventProcessor.cs
+++ b/Source/Application/Kysect.Shreks.Application.GithubWorkflow.Abstractions/IShreksWebhookEventProcessor.cs
@@ -5,7 +5,7 @@ namespace Kysect.Shreks.Application.GithubWorkflow.Abstractions;
 
 public interface IShreksWebhookEventProcessor
 {
-    Task ProcessPullRequestReopen(bool? isMerged, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier);
+    Task ProcessPullRequestReopen(GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier);
     Task ProcessPullRequestUpdate(GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier, CancellationToken cancellationToken);
     Task ProcessPullRequestClosed(bool merged, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier);
     Task ProcessPullRequestReviewComment(string? reviewComment, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestEventNotifier eventNotifier);

--- a/Source/Application/Kysect.Shreks.Application.GithubWorkflow.Abstractions/IShreksWebhookEventProcessor.cs
+++ b/Source/Application/Kysect.Shreks.Application.GithubWorkflow.Abstractions/IShreksWebhookEventProcessor.cs
@@ -8,8 +8,10 @@ public interface IShreksWebhookEventProcessor
     Task ProcessPullRequestReopen(GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier);
     Task ProcessPullRequestUpdate(GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier, CancellationToken cancellationToken);
     Task ProcessPullRequestClosed(bool merged, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier);
+
     Task ProcessPullRequestReviewComment(string? reviewComment, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestEventNotifier eventNotifier);
     Task ProcessPullRequestReviewRequestChanges(string? reviewBody, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestEventNotifier eventNotifier);
     Task ProcessPullRequestReviewApprove(string? commentBody, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestEventNotifier eventNotifier);
+
     Task ProcessIssueCommentCreate(string issueCommentBody, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommentEventNotifier eventNotifier);
 }

--- a/Source/Application/Kysect.Shreks.Application.GithubWorkflow/ShreksWebhookEventProcessor.cs
+++ b/Source/Application/Kysect.Shreks.Application.GithubWorkflow/ShreksWebhookEventProcessor.cs
@@ -42,10 +42,10 @@ public class ShreksWebhookEventProcessor : IShreksWebhookEventProcessor
         _githubSubmissionStateMachineFactory = new GithubSubmissionStateMachineFactory(_context, _shreksCommandProcessor);
     }
 
-    public async Task ProcessPullRequestReopen(bool? isMerged, GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier)
+    public async Task ProcessPullRequestReopen(GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier)
     {
         IGithubSubmissionStateMachine githubSubmissionStateMachine = await CreateStateMachine(prDescriptor, logger, eventNotifier);
-        await githubSubmissionStateMachine.ProcessPullRequestReopen(isMerged, prDescriptor);
+        await githubSubmissionStateMachine.ProcessPullRequestReopen(prDescriptor);
     }
 
     public async Task ProcessPullRequestUpdate(GithubPullRequestDescriptor prDescriptor, ILogger logger, IPullRequestCommitEventNotifier eventNotifier, CancellationToken cancellationToken)

--- a/Source/Application/Kysect.Shreks.Application.GithubWorkflow/SubmissionStateMachines/IGithubSubmissionStateMachine.cs
+++ b/Source/Application/Kysect.Shreks.Application.GithubWorkflow/SubmissionStateMachines/IGithubSubmissionStateMachine.cs
@@ -8,6 +8,6 @@ public interface IGithubSubmissionStateMachine
     Task ProcessPullRequestReviewApprove(IShreksCommand? command, GithubPullRequestDescriptor prDescriptor);
     Task ProcessPullRequestReviewRequestChanges(IShreksCommand? command);
     Task ProcessPullRequestReviewComment(IShreksCommand? command);
-    Task ProcessPullRequestReopen(bool? isMerged, GithubPullRequestDescriptor prDescriptor);
+    Task ProcessPullRequestReopen(GithubPullRequestDescriptor prDescriptor);
     Task ProcessPullRequestClosed(bool isMerged, GithubPullRequestDescriptor prDescriptor);
 }

--- a/Source/Application/Kysect.Shreks.Application.GithubWorkflow/SubmissionStateMachines/ReviewOnlyGithubSubmissionStateMachine.cs
+++ b/Source/Application/Kysect.Shreks.Application.GithubWorkflow/SubmissionStateMachines/ReviewOnlyGithubSubmissionStateMachine.cs
@@ -102,10 +102,9 @@ public class ReviewOnlyGithubSubmissionStateMachine : IGithubSubmissionStateMach
         }
     }
 
-    public async Task ProcessPullRequestReopen(bool? isMerged, GithubPullRequestDescriptor prDescriptor)
+    public async Task ProcessPullRequestReopen(GithubPullRequestDescriptor prDescriptor)
     {
-        if (isMerged.HasValue && isMerged == false)
-            await ChangeSubmissionState(SubmissionState.Active, prDescriptor);
+        await ChangeSubmissionState(SubmissionState.Active, prDescriptor);
     }
 
     public async Task ProcessPullRequestClosed(bool isMerged, GithubPullRequestDescriptor prDescriptor)

--- a/Source/Application/Kysect.Shreks.Application.GithubWorkflow/SubmissionStateMachines/ReviewWithDefenseGithubSubmissionStateMachine.cs
+++ b/Source/Application/Kysect.Shreks.Application.GithubWorkflow/SubmissionStateMachines/ReviewWithDefenseGithubSubmissionStateMachine.cs
@@ -83,10 +83,9 @@ public class ReviewWithDefenseGithubSubmissionStateMachine : IGithubSubmissionSt
         }
     }
 
-    public async Task ProcessPullRequestReopen(bool? isMerged, GithubPullRequestDescriptor prDescriptor)
+    public async Task ProcessPullRequestReopen(GithubPullRequestDescriptor prDescriptor)
     {
-        if (isMerged.HasValue && isMerged == false)
-            await ChangeSubmissionState(SubmissionState.Active, prDescriptor);
+        await ChangeSubmissionState(SubmissionState.Active, prDescriptor);
     }
 
     public async Task ProcessPullRequestClosed(bool isMerged, GithubPullRequestDescriptor prDescriptor)

--- a/Source/Domain/Kysect.Shreks.Common/Resources/UserMessages.Designer.cs
+++ b/Source/Domain/Kysect.Shreks.Common/Resources/UserMessages.Designer.cs
@@ -277,7 +277,7 @@ namespace Kysect.Shreks.Common.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User is not authorized to activate this submission..
+        ///   Looks up a localized string similar to User is not authorized to do this action..
         /// </summary>
         internal static string UnauthorizedExceptionMessage {
             get {

--- a/Source/Domain/Kysect.Shreks.Common/Resources/UserMessages.resx
+++ b/Source/Domain/Kysect.Shreks.Common/Resources/UserMessages.resx
@@ -190,7 +190,7 @@
     <value>Submission updated.\n{0}</value>
   </data>
   <data name="UnauthorizedExceptionMessage" xml:space="preserve">
-    <value>User is not authorized to activate this submission.</value>
+    <value>User is not authorized to do this action.</value>
   </data>
   <data name="UserDoesNotHavePermissionForActivateSubmission" xml:space="preserve">
     <value>User is not authorized to activate this submission.</value>

--- a/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Processors/ShreksWebhookEventProcessorProxy.cs
+++ b/Source/Infrastructure/Integration/Kysect.Shreks.Integration.Github/Processors/ShreksWebhookEventProcessorProxy.cs
@@ -64,8 +64,7 @@ public sealed class ShreksWebhookEventProcessorProxy : WebhookEventProcessor
                     break;
 
                 case PullRequestActionValue.Reopened:
-                    bool isMerged = pullRequestEvent.PullRequest.Merged ?? false;
-                    await _processor.ProcessPullRequestReopen(isMerged, githubPullRequestDescriptor, repositoryLogger, pullRequestCommitEventNotifier);
+                    await _processor.ProcessPullRequestReopen(githubPullRequestDescriptor, repositoryLogger, pullRequestCommitEventNotifier);
                     break;
 
                 case PullRequestActionValue.Closed:

--- a/Source/Tests/Kysect.Shreks.Tests/GithubWorkflow/GithubSubjectCourseAssociationTest.cs
+++ b/Source/Tests/Kysect.Shreks.Tests/GithubWorkflow/GithubSubjectCourseAssociationTest.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Kysect.Shreks.Tests.GithubWorkflow;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "<Pending>")]
 public class GithubSubjectCourseAssociationTest : GithubWorkflowTestBase
 {
     private readonly ILogger _logger;
@@ -121,6 +122,21 @@ public class GithubSubjectCourseAssociationTest : GithubWorkflowTestBase
 
         Submission submission = await _githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
 
+        Assert.Equal(SubmissionState.Active, submission.State);
+    }
+
+    [Fact]
+    public async Task ProcessPullRequestReviewApprove_ByStudent_ActionShouldBeForbidden()
+    {
+        GithubApplicationTestContext context = await TestContextGenerator.Create();
+        GithubPullRequestDescriptor githubPullRequestDescriptor = context.CreateStudentPullRequestDescriptor();
+
+        await _githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, _pullRequestCommitEventNotifier, CancellationToken.None);
+        await _githubSubmissionStateMachine.ProcessPullRequestReviewApprove(null, githubPullRequestDescriptor, _logger, _pullRequestCommitEventNotifier);
+
+        Submission submission = await _githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
+
+        Assert.Null(submission.Rating);
         Assert.Equal(SubmissionState.Active, submission.State);
     }
 

--- a/Source/Tests/Kysect.Shreks.Tests/GithubWorkflow/GithubSubjectCourseAssociationTest.cs
+++ b/Source/Tests/Kysect.Shreks.Tests/GithubWorkflow/GithubSubjectCourseAssociationTest.cs
@@ -2,6 +2,7 @@
 using Kysect.Shreks.Application.Commands.Parsers;
 using Kysect.Shreks.Application.DatabaseContextExtensions;
 using Kysect.Shreks.Application.GithubWorkflow;
+using Kysect.Shreks.Application.GithubWorkflow.Abstractions;
 using Kysect.Shreks.Application.GithubWorkflow.Abstractions.Models;
 using Kysect.Shreks.Application.GithubWorkflow.Submissions;
 using Kysect.Shreks.Application.TableManagement;
@@ -9,6 +10,7 @@ using Kysect.Shreks.Core.Models;
 using Kysect.Shreks.Core.Study;
 using Kysect.Shreks.Core.SubjectCourseAssociations;
 using Kysect.Shreks.Core.Submissions;
+using Kysect.Shreks.Core.Tools;
 using Kysect.Shreks.Core.UserAssociations;
 using Kysect.Shreks.Core.Users;
 using Kysect.Shreks.Tests.GithubWorkflow.Tools;
@@ -48,7 +50,7 @@ public class GithubSubjectCourseAssociationTest : GithubWorkflowTestBase
     {
         var pullRequestCommitEventNotifier = new TestEventNotifier();
         var githubSubmissionService = new GithubSubmissionService(Context);
-        ShreksWebhookEventProcessor githubSubmissionStateMachine = CreateEventProcessor();
+        IShreksWebhookEventProcessor githubSubmissionStateMachine = CreateEventProcessor();
 
         (GithubSubjectCourseAssociation subjectCourseAssociation, Student student) = await TestContextGenerator.Create();
         GithubUserAssociation githubUserAssociation = student.User.Associations.OfType<GithubUserAssociation>().First();
@@ -67,6 +69,37 @@ public class GithubSubjectCourseAssociationTest : GithubWorkflowTestBase
         Submission lastSubmissionByPr = await githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
 
         Assert.Equal(SubmissionState.Active, lastSubmissionByPr.State);
+    }
+
+    [Fact]
+    public async Task PullRequestUpdate_AfterSubmissionWasCreated_SubmissionShouldUpdateTime()
+    {
+        var pullRequestCommitEventNotifier = new TestEventNotifier();
+        var githubSubmissionService = new GithubSubmissionService(Context);
+        IShreksWebhookEventProcessor githubSubmissionStateMachine = CreateEventProcessor();
+
+        (GithubSubjectCourseAssociation subjectCourseAssociation, Student student) = await TestContextGenerator.Create();
+        GithubUserAssociation githubUserAssociation = student.User.Associations.OfType<GithubUserAssociation>().First();
+        Assignment assignment = subjectCourseAssociation.SubjectCourse.Assignments.First();
+
+        var githubPullRequestDescriptor = new GithubPullRequestDescriptor(
+            githubUserAssociation.GithubUsername,
+            string.Empty,
+            subjectCourseAssociation.GithubOrganizationName,
+            githubUserAssociation.GithubUsername,
+            assignment.ShortName,
+            1);
+
+        await githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, pullRequestCommitEventNotifier, CancellationToken.None);
+        Submission createdSubmission = await githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
+        // Do not inline, it lead to test failing
+        SpbDateTime submissionCreatedTime = createdSubmission.SubmissionDate;
+
+        await githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, pullRequestCommitEventNotifier, CancellationToken.None);
+        Submission updatedSubmission = await githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
+
+        Assert.Equal(updatedSubmission.Id, createdSubmission.Id);
+        Assert.NotEqual(updatedSubmission.SubmissionDate, submissionCreatedTime);
     }
 
     public ShreksWebhookEventProcessor CreateEventProcessor()

--- a/Source/Tests/Kysect.Shreks.Tests/GithubWorkflow/GithubSubjectCourseAssociationTest.cs
+++ b/Source/Tests/Kysect.Shreks.Tests/GithubWorkflow/GithubSubjectCourseAssociationTest.cs
@@ -7,12 +7,9 @@ using Kysect.Shreks.Application.GithubWorkflow.Abstractions.Models;
 using Kysect.Shreks.Application.GithubWorkflow.Submissions;
 using Kysect.Shreks.Application.TableManagement;
 using Kysect.Shreks.Core.Models;
-using Kysect.Shreks.Core.Study;
-using Kysect.Shreks.Core.SubjectCourseAssociations;
 using Kysect.Shreks.Core.Submissions;
 using Kysect.Shreks.Core.Tools;
 using Kysect.Shreks.Core.UserAssociations;
-using Kysect.Shreks.Core.Users;
 using Kysect.Shreks.Tests.GithubWorkflow.Tools;
 using Kysect.Shreks.Tests.Tools;
 using Microsoft.Extensions.Logging;
@@ -24,21 +21,28 @@ namespace Kysect.Shreks.Tests.GithubWorkflow;
 public class GithubSubjectCourseAssociationTest : GithubWorkflowTestBase
 {
     private readonly ILogger _logger;
+    private readonly TestEventNotifier _pullRequestCommitEventNotifier;
+    private readonly GithubSubmissionService _githubSubmissionService;
+    private readonly IShreksWebhookEventProcessor _githubSubmissionStateMachine;
 
     public GithubSubjectCourseAssociationTest(ITestOutputHelper output)
     {
         _logger = LogInitialization.InitTestLogger(output);
+
+        _pullRequestCommitEventNotifier = new TestEventNotifier();
+        _githubSubmissionService = new GithubSubmissionService(Context);
+        _githubSubmissionStateMachine = CreateEventProcessor();
     }
 
     [Fact]
     public async Task GetSubjectCourseGithubUser_StudentAssociationExists_AssociationShouldReturn()
     {
-        (GithubSubjectCourseAssociation subjectCourseAssociation, Student student) = await TestContextGenerator.Create();
-        GithubUserAssociation githubUserAssociation = student.User.Associations.OfType<GithubUserAssociation>().First();
+        GithubApplicationTestContext githubApplicationTestContext = await TestContextGenerator.Create();
+        GithubUserAssociation githubUserAssociation = githubApplicationTestContext.GetStudentGithubAssociation();
 
         IReadOnlyCollection<GithubUserAssociation> githubUserAssociations = await Context
             .SubjectCourses
-            .GetAllGithubUsers(subjectCourseAssociation.SubjectCourse.Id);
+            .GetAllGithubUsers(githubApplicationTestContext.SubjectCourseAssociation.SubjectCourse.Id);
 
         IEnumerable<string> organizationUsers = githubUserAssociations.Select(a => a.GithubUsername);
 
@@ -48,58 +52,33 @@ public class GithubSubjectCourseAssociationTest : GithubWorkflowTestBase
     [Fact]
     public async Task PullRequestCreated_SubmissionShouldBeCreated()
     {
-        var pullRequestCommitEventNotifier = new TestEventNotifier();
-        var githubSubmissionService = new GithubSubmissionService(Context);
-        IShreksWebhookEventProcessor githubSubmissionStateMachine = CreateEventProcessor();
+        GithubApplicationTestContext context = await TestContextGenerator.Create();
+        GithubPullRequestDescriptor githubPullRequestDescriptor = context.CreateStudentPullRequestDescriptor();
 
-        (GithubSubjectCourseAssociation subjectCourseAssociation, Student student) = await TestContextGenerator.Create();
-        GithubUserAssociation githubUserAssociation = student.User.Associations.OfType<GithubUserAssociation>().First();
-        Assignment assignment = subjectCourseAssociation.SubjectCourse.Assignments.First();
-
-        var githubPullRequestDescriptor = new GithubPullRequestDescriptor(
-            githubUserAssociation.GithubUsername,
-            string.Empty,
-            subjectCourseAssociation.GithubOrganizationName,
-            githubUserAssociation.GithubUsername,
-            assignment.ShortName,
-            1);
-
-
-        await githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, pullRequestCommitEventNotifier, CancellationToken.None);
-        Submission lastSubmissionByPr = await githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
+        await _githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, _pullRequestCommitEventNotifier, CancellationToken.None);
+        Submission lastSubmissionByPr = await _githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
 
         Assert.Equal(SubmissionState.Active, lastSubmissionByPr.State);
+        Assert.Single(_pullRequestCommitEventNotifier.PullRequestMessages);
     }
 
     [Fact]
     public async Task PullRequestUpdate_AfterSubmissionWasCreated_SubmissionShouldUpdateTime()
     {
-        var pullRequestCommitEventNotifier = new TestEventNotifier();
-        var githubSubmissionService = new GithubSubmissionService(Context);
-        IShreksWebhookEventProcessor githubSubmissionStateMachine = CreateEventProcessor();
+        GithubApplicationTestContext context = await TestContextGenerator.Create();
+        GithubPullRequestDescriptor githubPullRequestDescriptor = context.CreateStudentPullRequestDescriptor();
 
-        (GithubSubjectCourseAssociation subjectCourseAssociation, Student student) = await TestContextGenerator.Create();
-        GithubUserAssociation githubUserAssociation = student.User.Associations.OfType<GithubUserAssociation>().First();
-        Assignment assignment = subjectCourseAssociation.SubjectCourse.Assignments.First();
-
-        var githubPullRequestDescriptor = new GithubPullRequestDescriptor(
-            githubUserAssociation.GithubUsername,
-            string.Empty,
-            subjectCourseAssociation.GithubOrganizationName,
-            githubUserAssociation.GithubUsername,
-            assignment.ShortName,
-            1);
-
-        await githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, pullRequestCommitEventNotifier, CancellationToken.None);
-        Submission createdSubmission = await githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
+        await _githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, _pullRequestCommitEventNotifier, CancellationToken.None);
+        Submission createdSubmission = await _githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
         // Do not inline, it lead to test failing
         SpbDateTime submissionCreatedTime = createdSubmission.SubmissionDate;
 
-        await githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, pullRequestCommitEventNotifier, CancellationToken.None);
-        Submission updatedSubmission = await githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
+        await _githubSubmissionStateMachine.ProcessPullRequestUpdate(githubPullRequestDescriptor, _logger, _pullRequestCommitEventNotifier, CancellationToken.None);
+        Submission updatedSubmission = await _githubSubmissionService.GetLastSubmissionByPr(githubPullRequestDescriptor);
 
         Assert.Equal(updatedSubmission.Id, createdSubmission.Id);
         Assert.NotEqual(updatedSubmission.SubmissionDate, submissionCreatedTime);
+        Assert.Single(_pullRequestCommitEventNotifier.PullRequestMessages);
     }
 
     public ShreksWebhookEventProcessor CreateEventProcessor()

--- a/Source/Tests/Kysect.Shreks.Tests/GithubWorkflow/Tools/GithubApplicationTestContext.cs
+++ b/Source/Tests/Kysect.Shreks.Tests/GithubWorkflow/Tools/GithubApplicationTestContext.cs
@@ -1,8 +1,36 @@
-﻿using Kysect.Shreks.Core.SubjectCourseAssociations;
+﻿using Kysect.Shreks.Application.GithubWorkflow.Abstractions.Models;
+using Kysect.Shreks.Core.Study;
+using Kysect.Shreks.Core.SubjectCourseAssociations;
+using Kysect.Shreks.Core.UserAssociations;
 using Kysect.Shreks.Core.Users;
 
 namespace Kysect.Shreks.Tests.GithubWorkflow.Tools;
 
 public record GithubApplicationTestContext(
     GithubSubjectCourseAssociation SubjectCourseAssociation,
-    Student Student);
+    Student Student)
+{
+    public GithubUserAssociation GetStudentGithubAssociation()
+    {
+        return Student.User.Associations.OfType<GithubUserAssociation>().First();
+    }
+
+    public Assignment GetAssignment()
+    {
+        return SubjectCourseAssociation.SubjectCourse.Assignments.First();
+    }
+
+    public GithubPullRequestDescriptor CreateStudentPullRequestDescriptor()
+    {
+        GithubUserAssociation githubUserAssociation = GetStudentGithubAssociation();
+        Assignment assignment = GetAssignment();
+
+        return new GithubPullRequestDescriptor(
+            githubUserAssociation.GithubUsername,
+            string.Empty,
+            SubjectCourseAssociation.GithubOrganizationName,
+            githubUserAssociation.GithubUsername,
+            assignment.ShortName,
+            1);
+    }
+}


### PR DESCRIPTION
Добавил тесты на ивенты открытия и закрытия. Дошёл до ревью ивентов, нашёл что там нужно править, отдельно кину.

- isMerged удалён т.к. нельзя открыть смёрдженный PR -> всегда true там